### PR TITLE
allow other controllers to be used

### DIFF
--- a/ScheduLite.webservice/src/main/java/com/schedulite/schedulite/security/WebSecurityConfig.java
+++ b/ScheduLite.webservice/src/main/java/com/schedulite/schedulite/security/WebSecurityConfig.java
@@ -63,7 +63,7 @@ public class WebSecurityConfig { // extends WebSecurityConfigurerAdapter {
         http.cors().and().csrf().disable()
                 .exceptionHandling().authenticationEntryPoint(unauthorizedHandler).and()
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS).and()
-                .authorizeRequests().antMatchers("/api/v1/auth/**").permitAll()
+                .authorizeRequests().antMatchers("/api/v1/**").permitAll()
                 .anyRequest().authenticated();
 
         http.authenticationProvider(authenticationProvider());


### PR DESCRIPTION
fixed controller 401 authorization refusal
this was caused by incorrect filtering
to test:
run the webservice
make a post request for /api/v1/users/roles - should show possible roles
make a post request for /api/v1/courses - should show possible courses
