### PR TITLE
KW/ScheduleSaving

### DIFF
--- a/ScheduLite.webservice/src/main/java/com/schedulite/schedulite/controllers/AuthController.java
+++ b/ScheduLite.webservice/src/main/java/com/schedulite/schedulite/controllers/AuthController.java
@@ -2,6 +2,7 @@ package com.schedulite.schedulite.controllers;
 
 import com.schedulite.schedulite.models.ERole;
 import com.schedulite.schedulite.models.Role;
+import com.schedulite.schedulite.models.Schedule;
 import com.schedulite.schedulite.models.User;
 import com.schedulite.schedulite.repositories.RoleRepository;
 import com.schedulite.schedulite.repositories.UserRepository;
@@ -21,6 +22,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -116,6 +118,8 @@ public class AuthController {
         }
 
         user.setRoles(roles);
+        List<Schedule> schedules = new ArrayList<>();
+        user.setSchedules(schedules);
         userRepository.save(user);
 
         return ResponseEntity.ok(new MessageResponse("User registered successfully!"));

--- a/ScheduLite.webservice/src/main/java/com/schedulite/schedulite/controllers/UserController.java
+++ b/ScheduLite.webservice/src/main/java/com/schedulite/schedulite/controllers/UserController.java
@@ -1,13 +1,18 @@
 package com.schedulite.schedulite.controllers;
 
+import com.schedulite.schedulite.models.Schedule;
+import com.schedulite.schedulite.models.User;
 import com.schedulite.schedulite.services.RoleService;
+import com.schedulite.schedulite.services.UserDetailsImpl;
+import com.schedulite.schedulite.services.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.CrossOrigin;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+import java.util.Optional;
 
 @CrossOrigin(origins = "*", maxAge = 3600)
 @RestController
@@ -15,11 +20,31 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserController {
     @Autowired
     private RoleService roleService;
+    @Autowired
+    private UserService userService;
 
     @GetMapping("/roles")
     public ResponseEntity<?> getRoles() {
         return new ResponseEntity<>(roleService.getAllRoles(), HttpStatus.OK);
     }
 
+    @PostMapping("/add-schedule")
+    public ResponseEntity<?> postSchedule(@Valid @RequestBody Schedule newSchedule) {
+        String userId = ((UserDetailsImpl) SecurityContextHolder.getContext().getAuthentication().getPrincipal()).getId();
+        if (userId == null) {
+            return new ResponseEntity<>("Not logged in", HttpStatus.FORBIDDEN);
+        }
+
+        Optional<User> optionalUser = userService.getUserByUserId(userId);
+        if (optionalUser.isEmpty()) {
+            return new ResponseEntity<>("User does not exist", HttpStatus.FORBIDDEN);
+        }
+
+        User currentUser = optionalUser.get();
+        currentUser.addSchedule(newSchedule);
+        userService.setUpdatedUser(currentUser);
+
+        return new ResponseEntity<>(true, HttpStatus.OK);
+    }
 
 }

--- a/ScheduLite.webservice/src/main/java/com/schedulite/schedulite/controllers/UserController.java
+++ b/ScheduLite.webservice/src/main/java/com/schedulite/schedulite/controllers/UserController.java
@@ -20,4 +20,6 @@ public class UserController {
     public ResponseEntity<?> getRoles() {
         return new ResponseEntity<>(roleService.getAllRoles(), HttpStatus.OK);
     }
+
+
 }

--- a/ScheduLite.webservice/src/main/java/com/schedulite/schedulite/controllers/UserController.java
+++ b/ScheduLite.webservice/src/main/java/com/schedulite/schedulite/controllers/UserController.java
@@ -44,7 +44,47 @@ public class UserController {
         currentUser.addSchedule(newSchedule);
         userService.setUpdatedUser(currentUser);
 
-        return new ResponseEntity<>(true, HttpStatus.OK);
+        return new ResponseEntity<>("Successfully added schedule", HttpStatus.OK);
+    }
+
+    @PostMapping("remove-schedule")
+    public ResponseEntity<?> removeSchedule(@Valid @RequestBody Schedule oldSchedule) {
+        String userId = ((UserDetailsImpl) SecurityContextHolder.getContext().getAuthentication().getPrincipal()).getId();
+        if (userId == null) {
+            return new ResponseEntity<>("Not logged in", HttpStatus.FORBIDDEN);
+        }
+
+        Optional<User> optionalUser = userService.getUserByUserId(userId);
+        if (optionalUser.isEmpty()) {
+            return new ResponseEntity<>("User does not exist", HttpStatus.FORBIDDEN);
+        }
+        User currentUser = optionalUser.get();
+
+        currentUser.removeSchedule(oldSchedule.getScheduleName());
+        userService.setUpdatedUser(currentUser);
+
+        return new ResponseEntity<>("Successfully removed schedule", HttpStatus.OK);
+    }
+
+    @PostMapping("update-schedule")
+    public ResponseEntity<?> updateSchedule(@Valid @RequestBody Schedule updatedSchedule) {
+        String userId = ((UserDetailsImpl) SecurityContextHolder.getContext().getAuthentication().getPrincipal()).getId();
+        if (userId == null) {
+            return new ResponseEntity<>("Not logged in", HttpStatus.FORBIDDEN);
+        }
+
+        Optional<User> optionalUser = userService.getUserByUserId(userId);
+        if (optionalUser.isEmpty()) {
+            return new ResponseEntity<>("User does not exist", HttpStatus.FORBIDDEN);
+        }
+        User currentUser = optionalUser.get();
+
+        currentUser.removeSchedule(updatedSchedule.getScheduleName());
+        currentUser.addSchedule(updatedSchedule);
+
+        userService.setUpdatedUser(currentUser);
+
+        return new ResponseEntity<>("Successfully updated schedule", HttpStatus.OK);
     }
 
 }

--- a/ScheduLite.webservice/src/main/java/com/schedulite/schedulite/models/Schedule.java
+++ b/ScheduLite.webservice/src/main/java/com/schedulite/schedulite/models/Schedule.java
@@ -1,0 +1,56 @@
+package com.schedulite.schedulite.models;
+
+import org.springframework.data.mongodb.core.mapping.DocumentReference;
+
+import java.util.List;
+
+public class Schedule {
+    private String scheduleName;
+    private String semester;
+    @DocumentReference
+    private List<Course> tentativeCourseIds;
+    @DocumentReference
+    private List<Course> activeCourses;
+
+    public Schedule () {
+
+    }
+    public Schedule(String scheduleName, String semester, List<Course> tentativeCourseIds, List<Course> activeCourses) {
+        this.scheduleName = scheduleName;
+        this.semester = semester;
+        this.tentativeCourseIds = tentativeCourseIds;
+        this.activeCourses = activeCourses;
+    }
+
+    public String getScheduleName() {
+        return scheduleName;
+    }
+
+    public void setScheduleName(String scheduleName) {
+        this.scheduleName = scheduleName;
+    }
+
+    public String getSemester() {
+        return semester;
+    }
+
+    public void setSemester(String semester) {
+        this.semester = semester;
+    }
+
+    public List<Course> getTentativeCourseIds() {
+        return tentativeCourseIds;
+    }
+
+    public void setTentativeCourseIds(List<Course> tentativeCourseIds) {
+        this.tentativeCourseIds = tentativeCourseIds;
+    }
+
+    public List<Course> getActiveCourses() {
+        return activeCourses;
+    }
+
+    public void setActiveCourses(List<Course> activeCourses) {
+        this.activeCourses = activeCourses;
+    }
+}

--- a/ScheduLite.webservice/src/main/java/com/schedulite/schedulite/models/Schedule.java
+++ b/ScheduLite.webservice/src/main/java/com/schedulite/schedulite/models/Schedule.java
@@ -1,5 +1,6 @@
 package com.schedulite.schedulite.models;
 
+import org.springframework.data.mongodb.core.mapping.DBRef;
 import org.springframework.data.mongodb.core.mapping.DocumentReference;
 
 import java.util.List;
@@ -8,17 +9,17 @@ public class Schedule {
     private String scheduleName;
     private String semester;
     @DocumentReference
-    private List<Course> tentativeCourseIds;
-    @DocumentReference
     private List<Course> activeCourses;
+    @DocumentReference
+    private List<Course> tentativeCourses;
 
     public Schedule () {
 
     }
-    public Schedule(String scheduleName, String semester, List<Course> tentativeCourseIds, List<Course> activeCourses) {
+    public Schedule(String scheduleName, String semester, List<Course> tentativeCourses, List<Course> activeCourses) {
         this.scheduleName = scheduleName;
         this.semester = semester;
-        this.tentativeCourseIds = tentativeCourseIds;
+        this.tentativeCourses = tentativeCourses;
         this.activeCourses = activeCourses;
     }
 
@@ -39,11 +40,11 @@ public class Schedule {
     }
 
     public List<Course> getTentativeCourseIds() {
-        return tentativeCourseIds;
+        return tentativeCourses;
     }
 
-    public void setTentativeCourseIds(List<Course> tentativeCourseIds) {
-        this.tentativeCourseIds = tentativeCourseIds;
+    public void setTentativeCourseIds(List<Course> tentativeCourses) {
+        this.tentativeCourses = tentativeCourses;
     }
 
     public List<Course> getActiveCourses() {

--- a/ScheduLite.webservice/src/main/java/com/schedulite/schedulite/models/Schedule.java
+++ b/ScheduLite.webservice/src/main/java/com/schedulite/schedulite/models/Schedule.java
@@ -16,6 +16,7 @@ public class Schedule {
     public Schedule () {
 
     }
+
     public Schedule(String scheduleName, String semester, List<Course> tentativeCourses, List<Course> activeCourses) {
         this.scheduleName = scheduleName;
         this.semester = semester;
@@ -39,11 +40,11 @@ public class Schedule {
         this.semester = semester;
     }
 
-    public List<Course> getTentativeCourseIds() {
+    public List<Course> getTentativeCourses() {
         return tentativeCourses;
     }
 
-    public void setTentativeCourseIds(List<Course> tentativeCourses) {
+    public void setTentativeCourses (List<Course> tentativeCourses) {
         this.tentativeCourses = tentativeCourses;
     }
 

--- a/ScheduLite.webservice/src/main/java/com/schedulite/schedulite/models/User.java
+++ b/ScheduLite.webservice/src/main/java/com/schedulite/schedulite/models/User.java
@@ -1,5 +1,6 @@
 package com.schedulite.schedulite.models;
 
+import com.mongodb.lang.Nullable;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.DBRef;
 import org.springframework.data.mongodb.core.mapping.Document;
@@ -8,6 +9,7 @@ import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Size;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 @Document(collection = "users")
@@ -31,7 +33,10 @@ public class User {
     @DBRef
     private Set<Role> roles = new HashSet<>();
 
+    private List<Schedule> schedules;
+
     public User() {
+
     }
 
     public User(String username, String email, String password) {
@@ -78,5 +83,13 @@ public class User {
 
     public void setRoles(Set<Role> roles) {
         this.roles = roles;
+    }
+
+    public List<Schedule> getSchedules() {
+        return schedules;
+    }
+
+    public void setSchedules(List<Schedule> schedules) {
+        this.schedules = schedules;
     }
 }

--- a/ScheduLite.webservice/src/main/java/com/schedulite/schedulite/models/User.java
+++ b/ScheduLite.webservice/src/main/java/com/schedulite/schedulite/models/User.java
@@ -96,4 +96,13 @@ public class User {
     public void addSchedule(Schedule schedule) {
         schedules.add(schedule);
     }
+
+    public void removeSchedule(String scheduleName) {
+        for (Schedule schedule : schedules) {
+            if (schedule.getScheduleName().equals(scheduleName)) {
+                schedules.remove(schedule);
+                break;
+            }
+        }
+    }
 }

--- a/ScheduLite.webservice/src/main/java/com/schedulite/schedulite/models/User.java
+++ b/ScheduLite.webservice/src/main/java/com/schedulite/schedulite/models/User.java
@@ -92,4 +92,8 @@ public class User {
     public void setSchedules(List<Schedule> schedules) {
         this.schedules = schedules;
     }
+
+    public void addSchedule(Schedule schedule) {
+        schedules.add(schedule);
+    }
 }

--- a/ScheduLite.webservice/src/main/java/com/schedulite/schedulite/repositories/UserRepository.java
+++ b/ScheduLite.webservice/src/main/java/com/schedulite/schedulite/repositories/UserRepository.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 
 public interface UserRepository extends MongoRepository<User, String> {
     Optional<User> findByUsername(String username);
+    Optional<User> findById(String id);
 
     Boolean existsByUsername(String username);
 

--- a/ScheduLite.webservice/src/main/java/com/schedulite/schedulite/services/UserDetailsServiceImpl.java
+++ b/ScheduLite.webservice/src/main/java/com/schedulite/schedulite/services/UserDetailsServiceImpl.java
@@ -22,4 +22,6 @@ public class UserDetailsServiceImpl implements UserDetailsService {
 
         return UserDetailsImpl.build(user);
     }
+
+
 }

--- a/ScheduLite.webservice/src/main/java/com/schedulite/schedulite/services/UserService.java
+++ b/ScheduLite.webservice/src/main/java/com/schedulite/schedulite/services/UserService.java
@@ -1,0 +1,29 @@
+package com.schedulite.schedulite.services;
+
+import com.schedulite.schedulite.models.Course;
+import com.schedulite.schedulite.models.Schedule;
+import com.schedulite.schedulite.models.User;
+import com.schedulite.schedulite.repositories.CourseRepository;
+import com.schedulite.schedulite.repositories.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+public class UserService {
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private MongoTemplate mongoTemplate;
+
+    public Optional<User> getUserByUserId(String userId) {
+        return userRepository.findById(userId);
+    }
+
+    public void setUpdatedUser(User updatedUser) {
+        userRepository.save(updatedUser);
+    }
+}


### PR DESCRIPTION
added controllers necessary for adding, removing, and updating schedules.
The following JSON format must be followed for all schedule controllers:
{
    "scheduleName":<name>,
    "semester":<Fall/Spring>,
    "activeCourses":[
        {"id":<course_id>}
    ],
    "tentativeCourses":[
        {"id":<course_id>}
    ]
}
note that course_id is the uuid that MongoDB generated. This allows us to dynamically refer to the course collection.

to test:
sign in using postman
grab the returned bearer token
copy the bearer token in the authorization tab in postman (select bearer token)
make a new post request to the /users/add-schedule controller with the previously described JSON body
should get a 200 response, double check this on MongoDB Compass
make a new post request to the /users/update-schedule controller with some arbitrary change to active or tentative courses
should get a 200 response
make a new post request to the /users/remove-schedule controller. the body should be the schedule to be removed.
