### PR TITLE
changed all signin references to login and fixed thrashing bug

### DIFF
--- a/ScheduLite.webservice/src/main/java/com/schedulite/schedulite/controllers/AuthController.java
+++ b/ScheduLite.webservice/src/main/java/com/schedulite/schedulite/controllers/AuthController.java
@@ -2,12 +2,11 @@ package com.schedulite.schedulite.controllers;
 
 import com.schedulite.schedulite.models.ERole;
 import com.schedulite.schedulite.models.Role;
-import com.schedulite.schedulite.models.Schedule;
 import com.schedulite.schedulite.models.User;
 import com.schedulite.schedulite.repositories.RoleRepository;
 import com.schedulite.schedulite.repositories.UserRepository;
 import com.schedulite.schedulite.security.jwt.JwtUtils;
-import com.schedulite.schedulite.security.payload.request.SigninRequest;
+import com.schedulite.schedulite.security.payload.request.LoginRequest;
 import com.schedulite.schedulite.security.payload.request.SignupRequest;
 import com.schedulite.schedulite.security.payload.response.JwtResponse;
 import com.schedulite.schedulite.security.payload.response.MessageResponse;
@@ -44,8 +43,8 @@ public class AuthController {
     @Autowired
     JwtUtils jwtUtils;
 
-    @PostMapping("/signin")
-    public ResponseEntity<?> authenticateUser(@Valid @RequestBody SigninRequest loginRequest) {
+    @PostMapping("/login")
+    public ResponseEntity<?> authenticateUser(@Valid @RequestBody LoginRequest loginRequest) {
 
         // checking for valid username and password
         Authentication authentication = authenticationManager.authenticate(

--- a/ScheduLite.webservice/src/main/java/com/schedulite/schedulite/security/payload/request/LoginRequest.java
+++ b/ScheduLite.webservice/src/main/java/com/schedulite/schedulite/security/payload/request/LoginRequest.java
@@ -2,7 +2,7 @@ package com.schedulite.schedulite.security.payload.request;
 
 import javax.validation.constraints.NotBlank;
 
-public class SigninRequest {
+public class LoginRequest {
     @NotBlank
     private String username;
 

--- a/schedulite.clientapp/src/App.tsx
+++ b/schedulite.clientapp/src/App.tsx
@@ -187,7 +187,7 @@ function App() {
                     <AnimatePresence mode={"wait"}>
                         <Routes location={location} key={location.pathname}>
                             {/*<Route path="/" element={<Home />} />*/}
-                            <Route path="/signin" element={<Login />} />
+                            <Route path="/login" element={<Login />} />
                             <Route path="/signup" element={<Signup />} />
                             <Route path="/*" Component={DefaultRoutes} />
                         </Routes>

--- a/schedulite.clientapp/src/components/AuthOptions/AuthOptions.tsx
+++ b/schedulite.clientapp/src/components/AuthOptions/AuthOptions.tsx
@@ -10,7 +10,7 @@ const AuthOptions = () => {
             <button className="auth-button signup" onClick={() => { navigate("/signup") }}>
                 Sign Up
             </button>
-            <button className="auth-button login" onClick={() => { navigate("/signin") }}>
+            <button className="auth-button login" onClick={() => { navigate("/login") }}>
                 Log In
             </button>
         </div>

--- a/schedulite.clientapp/src/components/NavBar/NavBar.tsx
+++ b/schedulite.clientapp/src/components/NavBar/NavBar.tsx
@@ -8,17 +8,10 @@ import {useLocation} from "react-router-dom";
 
 const NavBar = () => {
     const { user } = useContext(UserContext) as UserContextType;
-    const [loggedIn, setLoggedIn] = useState<boolean>(false);
     const { name } = useContext(ScheduleContext) as ScheduleContextType
 
     const location = useLocation()
-    console.log(location)
-    useEffect(() => {
-        console.log(user);
-        if (user !== null) {
-            setLoggedIn(true);
-        }
-    },[user])
+
 
     return (
         <div className="navbar">
@@ -34,7 +27,7 @@ const NavBar = () => {
 
             </div>
             <div className="right-side-container">
-                {loggedIn ? <UserOptions /> : <AuthOptions />}
+                {user !== null ? <UserOptions /> : <AuthOptions />}
             </div>
         </div>
     )

--- a/schedulite.clientapp/src/screens/LoginScreen/login.screen.tsx
+++ b/schedulite.clientapp/src/screens/LoginScreen/login.screen.tsx
@@ -12,8 +12,7 @@ const Login = () => {
     const navigate = useNavigate();
     
     useEffect(() => {
-        const currentUser = AuthService.getCurrentUser();
-        if (currentUser) {
+        if (AuthService.getCurrentUser() !== null) {
             navigate("/profile",{replace:true});
         }
     },[])

--- a/schedulite.clientapp/src/screens/LoginScreen/login.screen.tsx
+++ b/schedulite.clientapp/src/screens/LoginScreen/login.screen.tsx
@@ -1,16 +1,18 @@
-import React, { useState, useEffect } from 'react';
+import React, {useState, useEffect, useContext} from 'react';
 import { useNavigate } from "react-router-dom";
 import { Formik, Field, Form, ErrorMessage } from "formik";
 import * as Yup from "yup";
 import "./LoginScreen.scss"
 
 import AuthService from "../../services/auth.service";
+import {UserContext, UserContextType} from "../../context/UserContext";
 
 const Login = () => {
     const [loading, setLoading] = useState<boolean>(false);
     const [message, setMessage] = useState<string>("");
     const navigate = useNavigate();
-    
+    const { setUser } = useContext(UserContext) as UserContextType
+
     useEffect(() => {
         if (AuthService.getCurrentUser() !== null) {
             navigate("/profile",{replace:true});
@@ -30,6 +32,7 @@ const Login = () => {
         setLoading(true);
         AuthService.login(username, password).then(
             () => {
+                setUser(AuthService.getCurrentUser());
                 navigate("/profile",{replace:true});
             },
             error => {

--- a/schedulite.clientapp/src/screens/ProfileScreen/profile.screen.tsx
+++ b/schedulite.clientapp/src/screens/ProfileScreen/profile.screen.tsx
@@ -6,13 +6,12 @@ import { UserContext, UserContextType } from '../../context/UserContext';
 
 const Profile = () => {
     const navigate = useNavigate();
-    const { user } = useContext(UserContext) as UserContextType;
 
     useEffect(() => {
-        if (user === null) {
-            navigate("/login");
+        if (AuthService.getCurrentUser() === null) {
+            navigate("/login", { replace: true });
         }
-    }, [user])
+    }, [])
     return (
         <div>
             <VerticalTabs />

--- a/schedulite.clientapp/src/screens/ProfileScreen/profile.screen.tsx
+++ b/schedulite.clientapp/src/screens/ProfileScreen/profile.screen.tsx
@@ -7,11 +7,10 @@ import { UserContext, UserContextType } from '../../context/UserContext';
 const Profile = () => {
     const navigate = useNavigate();
     const { user } = useContext(UserContext) as UserContextType;
-    const [userData, setUserData] = useState<string>("");
 
     useEffect(() => {
         if (user === null) {
-            navigate("/signin");
+            navigate("/login");
         }
     }, [user])
     return (
@@ -19,7 +18,7 @@ const Profile = () => {
             <VerticalTabs />
             <button onClick={() => {
                 AuthService.logout();
-                navigate("/signin");
+                navigate("/login");
             }}>
                 Log Out
             </button>

--- a/schedulite.clientapp/src/screens/SignupScreen/signup.screen.tsx
+++ b/schedulite.clientapp/src/screens/SignupScreen/signup.screen.tsx
@@ -129,7 +129,7 @@ const Signup = () => {
       <label>
         already have an account?
       </label>
-      <button onClick={() => { navigate("/signin") }}>
+      <button onClick={() => { navigate("/login") }}>
         sign in
       </button>
     </div>

--- a/schedulite.clientapp/src/screens/SignupScreen/signup.screen.tsx
+++ b/schedulite.clientapp/src/screens/SignupScreen/signup.screen.tsx
@@ -1,14 +1,16 @@
-import React, { useState, useEffect } from 'react';
+import React, {useState, useEffect, useContext} from 'react';
 import { Formik, Field, Form, ErrorMessage } from "formik";
 import { useNavigate } from 'react-router';
 import * as Yup from "yup";
 import "./SignupScreen.scss"
 import AuthService from '../../services/auth.service';
+import {UserContext, UserContextType} from "../../context/UserContext";
 
 const Signup = () => {
   const [successful, setSuccessful] = useState<boolean>(false);
   const [message, setMessage] = useState<string>("");
   const navigate = useNavigate();
+  const { setUser } = useContext(UserContext) as UserContextType
 
   function validationSchema() {
     return Yup.object().shape({
@@ -53,6 +55,7 @@ const Signup = () => {
         setMessage(response.data.message);
         setSuccessful(true);
         AuthService.login(username,password);
+        setUser(AuthService.getCurrentUser());
         navigate("/schedule-selection");
       },
       error => {

--- a/schedulite.clientapp/src/services/auth.service.ts
+++ b/schedulite.clientapp/src/services/auth.service.ts
@@ -1,10 +1,11 @@
+import { MdSouth } from "react-icons/md";
 import axios from "../api/axios-config";
 
 const authPrefix = 'auth'
 class AuthService {
   login(username: string, password: string) {
     return axios
-      .post(authPrefix + "/signin", {
+      .post(authPrefix + "/login", {
         username,
         password
       })


### PR DESCRIPTION
Fixed login/signin thrashing bug

To test:
start app
on private tab, open to app and click login or signup
login or signup
no thrashing between screens should occur

quickly click the profile icon
navbar should remained in the logged in state